### PR TITLE
Revert "fix: improve output clarity for skipped files" -m "Previously, Bandit would show \"No issues identified\" when files were skipped, which was misleading. This change improves the output to:\n\n- Show a message about skipped files when appropriate\n- Maintain existing behavior when issues are found\n- Add test cases to verify the behavior\n- Update documentation to reflect changes\n- Fix PEP8 line length issues in formatters\n\nThe changes ensure users get clear feedback about skipped files while preserving all existing functionality."

### DIFF
--- a/bandit/core/manager.py
+++ b/bandit/core/manager.py
@@ -277,12 +277,6 @@ class BanditManager:
         for count, fname in enumerate(files):
             LOG.debug("working on file : %s", fname)
 
-            if fname != "-" and not os.path.exists(fname):
-                LOG.error("File not found: %s", fname)
-                self.skipped.append((fname, "File not found"))
-                new_files_list.remove(fname)
-                continue
-
             try:
                 if fname == "-":
                     open_fd = os.fdopen(sys.stdin.fileno(), "rb", 0)

--- a/bandit/formatters/screen.py
+++ b/bandit/formatters/screen.py
@@ -23,10 +23,6 @@ This formatter outputs the issues as color coded text to screen.
     5       y = yaml.load(ystr)
     6       yaml.dump(y)
 
-    Files were skipped during the scan. See 'Files skipped' section below.
-    Files skipped (1):
-        missing_file.py (File not found)
-
 .. versionadded:: 0.9.0
 
 .. versionchanged:: 1.5.0
@@ -35,8 +31,6 @@ This formatter outputs the issues as color coded text to screen.
 .. versionchanged:: 1.7.3
     New field `CWE` added to output
 
-.. versionchanged:: 1.7.4
-    Improved handling of skipped files in output
 """
 import datetime
 import logging
@@ -161,17 +155,6 @@ def get_results(manager, sev_level, conf_level, lines):
     baseline = not isinstance(issues, list)
     candidate_indent = " " * 10
 
-    # Check if there are any skipped files first
-    skipped = manager.get_skipped()
-    if skipped and not len(issues):
-        bits.append(
-            header(
-                "\tFiles were skipped during the scan. "
-                "See 'Files skipped' section below."
-            )
-        )
-        return "\n".join([bit for bit in bits])
-
     if not len(issues):
         return "\tNo issues identified."
 
@@ -228,7 +211,6 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
             bits.append(get_verbose_details(manager))
 
         bits.append(header("\nTest results:"))
-        issues = manager.get_issue_list(sev_level, conf_level)
         bits.append(get_results(manager, sev_level, conf_level, lines))
         bits.append(header("\nCode scanned:"))
         bits.append(
@@ -244,13 +226,6 @@ def report(manager, fileobj, sev_level, conf_level, lines=-1):
         bits.append(get_metrics(manager))
         skipped = manager.get_skipped()
         bits.append(header("Files skipped (%i):", len(skipped)))
-        if skipped and not len(issues):
-            bits.append(
-                header(
-                    "\tFiles were skipped during the scan. "
-                    "See 'Files skipped' section below."
-                )
-            )
         bits.extend(["\t%s (%s)" % skip for skip in skipped])
         do_print(bits)
 

--- a/bandit/formatters/text.py
+++ b/bandit/formatters/text.py
@@ -23,10 +23,6 @@ This formatter outputs the issues as plain text.
     5       y = yaml.load(ystr)
     6       yaml.dump(y)
 
-    Files were skipped during the scan. See 'Files skipped' section below.
-    Files skipped (1):
-        missing_file.py (File not found)
-
 .. versionadded:: 0.9.0
 
 .. versionchanged:: 1.5.0
@@ -34,9 +30,6 @@ This formatter outputs the issues as plain text.
 
 .. versionchanged:: 1.7.3
     New field `CWE` added to output
-
-.. versionchanged:: 1.7.4
-    Improved handling of skipped files in output
 
 """
 import datetime
@@ -127,15 +120,6 @@ def get_results(manager, sev_level, conf_level, lines):
     issues = manager.get_issue_list(sev_level, conf_level)
     baseline = not isinstance(issues, list)
     candidate_indent = " " * 10
-
-    # Check if there are any skipped files first
-    skipped = manager.get_skipped()
-    if skipped and not len(issues):
-        bits.append(
-            "\tFiles were skipped during the scan. "
-            "See 'Files skipped' section below."
-        )
-        return "\n".join([bit for bit in bits])
 
     if not len(issues):
         return "\tNo issues identified."

--- a/tests/unit/formatters/test_screen.py
+++ b/tests/unit/formatters/test_screen.py
@@ -99,26 +99,6 @@ class ScreenFormatterTests(testtools.TestCase):
             )
 
     @mock.patch("bandit.core.manager.BanditManager.get_issue_list")
-    def test_skipped_files_message(self, get_issue_list):
-        conf = config.BanditConfig()
-        self.manager = manager.BanditManager(conf, "file")
-        self.manager.skipped = [("missing_file.py", "File not found")]
-
-        (tmp_fd, self.tmp_fname) = tempfile.mkstemp()
-        self.manager.out_file = self.tmp_fname
-
-        get_issue_list.return_value = collections.OrderedDict()
-        with mock.patch("bandit.formatters.screen.do_print") as m:
-            with open(self.tmp_fname, "w") as tmp_file:
-                screen.report(
-                    self.manager, tmp_file, bandit.LOW, bandit.LOW, lines=5
-                )
-            output = "\n".join([str(a) for a in m.call_args])
-            self.assertIn("Files were skipped during the scan", output)
-            self.assertNotIn("No issues identified", output)
-            self.assertIn("missing_file.py (File not found)", output)
-
-    @mock.patch("bandit.core.manager.BanditManager.get_issue_list")
     def test_report_nobaseline(self, get_issue_list):
         conf = config.BanditConfig()
         self.manager = manager.BanditManager(conf, "file")

--- a/tests/unit/formatters/test_text.py
+++ b/tests/unit/formatters/test_text.py
@@ -84,27 +84,6 @@ class TextFormatterTests(testtools.TestCase):
             self.assertIn("No issues identified.", data)
 
     @mock.patch("bandit.core.manager.BanditManager.get_issue_list")
-    def test_skipped_files_message(self, get_issue_list):
-        conf = config.BanditConfig()
-        self.manager = manager.BanditManager(conf, "file")
-        self.manager.skipped = [("missing_file.py", "File not found")]
-
-        (tmp_fd, self.tmp_fname) = tempfile.mkstemp()
-        self.manager.out_file = self.tmp_fname
-
-        get_issue_list.return_value = collections.OrderedDict()
-        with open(self.tmp_fname, "w") as tmp_file:
-            b_text.report(
-                self.manager, tmp_file, bandit.LOW, bandit.LOW, lines=5
-            )
-
-        with open(self.tmp_fname) as f:
-            data = f.read()
-            self.assertIn("Files were skipped during the scan", data)
-            self.assertNotIn("No issues identified", data)
-            self.assertIn("missing_file.py (File not found)", data)
-
-    @mock.patch("bandit.core.manager.BanditManager.get_issue_list")
     def test_report_nobaseline(self, get_issue_list):
         conf = config.BanditConfig()
         self.manager = manager.BanditManager(conf, "file")


### PR DESCRIPTION
Reverts Rishimegamind/bandit#1